### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/VaiTon/ipfsgatewaychecker/security/code-scanning/1](https://github.com/VaiTon/ipfsgatewaychecker/security/code-scanning/1)

To fix this problem, we need to add a `permissions` block to the workflow (at the workflow or job level) specifying least requirements. Since the only job shown (`check: NPM check`) runs lint, install, and check commands and does not modify the repository, the minimal permission required is likely `contents: read`. This can be added either at the top level (applying to all jobs) or specifically to the `check` job. Based on CodeQL's recommendation and to cover current usage and future additions, the best is to add it just below the workflow name. Edit `.github/workflows/ci.yml`, inserting:
```yaml
permissions:
  contents: read
```
after the `name: CI` (on line 1-2). No additional imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
